### PR TITLE
Add the no-reorder attribute

### DIFF
--- a/pascal-triangle/riot/js/pascal-triangle.tag
+++ b/pascal-triangle/riot/js/pascal-triangle.tag
@@ -12,7 +12,7 @@
     </div>
     <div>
         <div each={line in list}>
-            <triangle-item each={item in line} text={item}></triangle-item>
+            <triangle-item each={item in line} no-reorder text={item}></triangle-item>
         </div>
     </div>
     <script>


### PR DESCRIPTION
The `no-reorder` attribute enables a faster riot rendering algorithm for loops that are not keyed like in this case